### PR TITLE
Optimised databus client dockerfile

### DIFF
--- a/databus_client/Dockerfile
+++ b/databus_client/Dockerfile
@@ -2,8 +2,8 @@
 FROM python:3.7-slim-buster
 WORKDIR /code
 
-COPY . .
-RUN pip install -r /code/network-insight-sdk-python/databus_client/requirements.txt
+COPY . /code/databus_client/.
+RUN pip install -r /code/databus_client/requirements.txt
 
-ENV PYTHONPATH "${PYTHONPATH}:/code/network-insight-sdk-python/"
-ENTRYPOINT ["python3", "/code/network-insight-sdk-python/databus_client/endpoint/client_endpoint.py"]
+ENV PYTHONPATH "${PYTHONPATH}:/code/databus_client/"
+ENTRYPOINT ["python3", "/code/databus_client/endpoint/client_endpoint.py"]


### PR DESCRIPTION
Old image size - vrni-eso.artifactory.eng.vmware.com/vrni_databus_client         v11               d30101c07669   7 months ago    3.72GB

New image size - vrni-eso.artifactory.eng.vmware.com/vrni_databus_client         v12               70596937e344   3 days ago      166MB